### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides email sending capabilities for Claude and other MCP-compatible AI assistants.
 
+<a href="https://glama.ai/mcp/servers/9u1qq6tli6">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/9u1qq6tli6/badge" alt="SMTP Server MCP server" />
+</a>
+
 ## Features
 
 - **Multiple SMTP Configurations**: Configure and manage multiple SMTP servers
@@ -227,4 +231,4 @@ Parameters: None
 
 ## License
 
-MIT 
+MIT


### PR DESCRIPTION
This PR adds a badge for the [SMTP MCP Server](https://glama.ai/mcp/servers/9u1qq6tli6) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/9u1qq6tli6">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/9u1qq6tli6/badge" alt="SMTP Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.